### PR TITLE
Use `config.yaml` for the filename in a gist

### DIFF
--- a/src/components/SettingsTab.component.ts
+++ b/src/components/SettingsTab.component.ts
@@ -78,7 +78,7 @@ export class SyncConfigSettingsTabComponent implements OnInit {
                 delete store.syncConfig;
 
                 // config file
-                files.push(new GistFile('config.json', yaml.dump(store)));
+                files.push(new GistFile('config.yaml', yaml.dump(store)));
 
                 // ssh password
                 files.push(new GistFile('ssh.auth.json', JSON.stringify(await this.getSSHPluginAllPasswordInfos(token))));
@@ -89,7 +89,13 @@ export class SyncConfigSettingsTabComponent implements OnInit {
 
                 const result = await getGist(type, token, baseUrl, gist);
 
-                if (result.has('config.json')) {
+                if (result.has('config.yaml')) {
+                    const config = yaml.load(result.get('config.yaml').value) as any;
+                    config.syncConfig = selfConfig;
+                    this.config.writeRaw(yaml.dump(config));
+                }
+                // Maintain a check for `config.json` for backwards-compatibility.
+                else if (result.has('config.json')) {
                     const config = yaml.load(result.get('config.json').value) as any;
                     config.syncConfig = selfConfig;
                     this.config.writeRaw(yaml.dump(config));


### PR DESCRIPTION
Gists are being uploaded in YAML format, which is appropriate since that is the storage format on disk. However, this format is being stored as `config.json`, which is incompatible with YAML syntax, loses syntax highlighting in the gist, and could be confusing.

This PR would migrate the file name to `config.yaml` with backwards compatibility should a gist already include a `config.json` file. In the event that a `config.yaml` file does not exist, `config.json` will be used and the YAML file name will be created on next sync.